### PR TITLE
change default GC rts params

### DIFF
--- a/buildsome.cabal
+++ b/buildsome.cabal
@@ -28,7 +28,7 @@ flag Charts
 executable buildsome
   hs-source-dirs:    src/
   main-is:           Main.hs
-  ghc-options:       -threaded -Wall -O2 -fsimpl-tick-factor=1000
+  ghc-options:       -threaded -Wall -O2 -fsimpl-tick-factor=1000 -with-rtsopts=-A4194304 -with-rtsopts=-H536870912
   ghc-prof-options:  -threaded -auto-all -caf-all -O2 -rtsopts
   other-modules:     Buildsome
                ,     Buildsome.BuildId


### PR DESCRIPTION
Change default rtsops -A and -H following tests done using ghc-gc-tune - seems to improve performance by about 30% in some cases.

A hack, but works. 