### PR TITLE
CompatMakefile: Workaround for make not handling odd characters well

### DIFF
--- a/src/Buildsome/CompatMakefile.hs
+++ b/src/Buildsome/CompatMakefile.hs
@@ -66,7 +66,7 @@ onOneTarget phoniesSet cwd stats target =
     depTgts <- lift $ mapM makefileTarget directDeps
     let
       targetDecl = mconcat
-        [ makefileTargetPath tgt, ":"
+        [ "T := ", makefileTargetPath tgt, "\n$(T):"
         , spaceUnwords $ map makefileTargetPath depTgts
         ]
       myLines =


### PR DESCRIPTION
See issue #35 