### PR TITLE
add csv output

### DIFF
--- a/buildsome.cabal
+++ b/buildsome.cabal
@@ -108,6 +108,7 @@ executable buildsome
                ,     async >=2.0 && <2.1
                ,     binary >=0.7 && <0.8
                ,     bytestring >=0.10 && <0.11
+               ,     cassava >=0.4.2 && <0.5
                ,     containers >=0.5 && <0.6
                ,     cryptohash >=0.11 && <0.12
                ,     data-default ==0.5.*

--- a/src/Buildsome.hs
+++ b/src/Buildsome.hs
@@ -222,6 +222,7 @@ assertExplicitInputsExist BuildTargetEnv{..} paths = do
     Left err | bteExplicitlyDemanded -> E.throwIO err
              | otherwise -> return ExplicitPathsNotBuilt
 
+-- | Top-level root target
 want :: Printer -> Buildsome -> Reason -> [FilePath] -> IO BuiltTargets
 want printer buildsome reason paths = do
   printStrLn printer $

--- a/src/Buildsome/BuildMaps.hs
+++ b/src/Buildsome/BuildMaps.hs
@@ -25,7 +25,11 @@ import qualified Data.Map.Strict as M
 import qualified Lib.Makefile as Makefile
 import qualified Lib.StringPattern as StringPattern
 
-newtype TargetRep = TargetRep { targetRepPath :: FilePath } -- We use the minimum output path as the target key/representative
+-- | Unique identifier of the target.
+newtype TargetRep = TargetRep { targetRepPath :: FilePath } -- We use the minimum output path as the
+                                                            -- target key/representative. It's ok to
+                                                            -- do this because each target outputs
+                                                            -- can't overlap
   deriving (Eq, Ord, Show)
 computeTargetRep :: Target -> TargetRep
 computeTargetRep = TargetRep . minimum . targetOutputs

--- a/src/Buildsome/Chart.hs
+++ b/src/Buildsome/Chart.hs
@@ -14,6 +14,8 @@ import Lib.FilePath (FilePath)
 import qualified Buildsome.BuildMaps as BuildMaps
 import qualified Buildsome.Stats as Stats
 import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy.Char8 as LBS8
+import qualified Data.Csv as Csv
 import qualified Data.Map as M
 
 #ifdef WITH_CHARTS_SUPPORT
@@ -102,7 +104,25 @@ makeDotChart stats filePath = do
   putStrLn $ "Writing dot file to " ++ show filePath
   BS8.writeFile (BS8.unpack filePath) $ dotRenderGraph "Dependencies" $ statsGraph stats
 
+
+toCSV :: Stats -> ByteString
+toCSV stats = LBS8.toStrict . Csv.encode . map toRow . M.toList $ ofTarget stats
+  where
+    toRow (targetRep, targetStats) = 
+      ( show targetRep
+      , show $ Stats.tsWhen targetStats
+      , (truncate $ 1000 * Stats.tsTime targetStats) :: Integer
+      )
+
+makeCSVFile :: Stats -> FilePath -> IO ()
+makeCSVFile stats filePath = do
+  putStrLn $ "Writing csv file to " ++ show filePath
+  BS8.writeFile (BS8.unpack filePath) $ toCSV stats
+    
+    
 make :: Stats -> FilePath -> IO ()
 make stats filePathBase = do
   makePieChart stats (filePathBase <> ".svg")
   makeDotChart stats (filePathBase <> ".dot")
+  makeCSVFile stats (filePathBase <> ".csv")
+  

--- a/src/Buildsome/Stats.hs
+++ b/src/Buildsome/Stats.hs
@@ -16,6 +16,7 @@ data When = FromCache | BuiltNow deriving Show
 
 data TargetStats = TargetStats
   { tsWhen :: !When
+    -- | How long it took to run
   , tsTime :: !DiffTime
   , tsDirectDeps :: [Target]
   } deriving (Show)


### PR DESCRIPTION
Note: not adding the csv deps under Charts flag on purpose, because these deps are much more lightweight  than the Cario stuff, and should be easily supported on all platforms.