### PR TITLE
Getdir stack usage

### DIFF
--- a/src/Lib/FileDesc.hs
+++ b/src/Lib/FileDesc.hs
@@ -153,7 +153,7 @@ fileContentDescOfStat path stat
   | Posix.isRegularFile stat =
     FileContentDescRegular . MD5.hash <$> BS8.readFile (BS8.unpack path)
   | Posix.isDirectory stat =
-    FileContentDescDir . MD5.hash . BS8.unlines <$> Dir.getDirectoryContents path
+    FileContentDescDir <$> Dir.getDirectoryContentsHash path
   | Posix.isSymbolicLink stat =
     FileContentDescSymlink <$> Posix.readSymbolicLink path
   | otherwise = E.throwIO $ UnsupportedFileTypeError path

--- a/test/runtests
+++ b/test/runtests
@@ -2,7 +2,7 @@
 
 set -e
 
-buildsome=$(realpath ../dist/build/buildsome/buildsome)
+buildsome="$(realpath ../dist/build/buildsome/buildsome) $@"
 
 ${buildsome} -f implicitphony
 git clean -fdx -- implicitphony


### PR DESCRIPTION
Avoids building a big list of files when all we want is an MD5 hash of their names